### PR TITLE
Fix layout overflow and responsive wrapping

### DIFF
--- a/src/components/NightSkyBackground.tsx
+++ b/src/components/NightSkyBackground.tsx
@@ -157,10 +157,9 @@ const NightSkyBackground: React.FC = () => {
             ref={canvasRef}
             sx={{
                 position: 'fixed',
-                top: 0,
-                left: 0,
-                width: '100vw',
-                height: '100vh',
+                inset: 0,
+                width: '100%',
+                height: '100%',
                 pointerEvents: 'none',
                 zIndex: 0,
             }}

--- a/src/pages/NotePage.tsx
+++ b/src/pages/NotePage.tsx
@@ -33,7 +33,7 @@ const NotePage: React.FC = () => {
     }, [slug]);
 
     return (
-        <Box sx={{ maxWidth: 780, mx: 'auto', minWidth: 0, pb: 8 }}>
+        <Box sx={{ width: '100%', maxWidth: 780, mx: 'auto', minWidth: 0, pb: 8, overflowX: 'clip' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
                 <IconButton onClick={() => navigate('/notes')} sx={{ mr: 2 }} aria-label="back">
                     <ArrowBackIcon />
@@ -75,7 +75,7 @@ const NotePage: React.FC = () => {
                                 direction="row"
                                 spacing={2}
                                 alignItems="center"
-                                sx={{ mb: 2, flexWrap: 'wrap', opacity: 0.8 }}
+                                sx={{ mb: 2, flexWrap: 'wrap', opacity: 0.8, minWidth: 0 }}
                                 useFlexGap
                             >
                                 {metadata.date && (
@@ -98,9 +98,15 @@ const NotePage: React.FC = () => {
                             </Stack>
 
                             {metadata.tags?.length > 0 && (
-                                <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }} useFlexGap>
+                                <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', minWidth: 0 }} useFlexGap>
                                     {metadata.tags.map((tag: string) => (
-                                        <Chip key={tag} label={tag} size="small" variant="outlined" />
+                                        <Chip
+                                            key={tag}
+                                            label={tag}
+                                            size="small"
+                                            variant="outlined"
+                                            sx={{ maxWidth: '100%', '& .MuiChip-label': { overflowWrap: 'anywhere' } }}
+                                        />
                                     ))}
                                 </Stack>
                             )}

--- a/src/styles/markdown-prose.css
+++ b/src/styles/markdown-prose.css
@@ -14,6 +14,9 @@
   line-height: 1.7;
   font-size: 0.95rem;
   color: inherit;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .markdown-prose>*:first-child {
@@ -112,6 +115,7 @@
   margin-bottom: 0.4em;
   overflow-wrap: anywhere;
   word-break: break-word;
+  min-width: 0;
 }
 
 .markdown-prose li>p {
@@ -135,6 +139,7 @@
   display: flex;
   align-items: flex-start;
   gap: 0.6em;
+  min-width: 0;
 }
 
 .markdown-prose .task-list-item input[type="checkbox"] {
@@ -186,6 +191,7 @@
   border-radius: 12px;
   overflow: hidden;
   position: relative;
+  max-width: 100%;
 }
 
 .markdown-prose pre code {
@@ -231,16 +237,18 @@
 
 /* ---- Tables ---- */
 .markdown-prose .table-wrapper {
-  overflow-x: auto;
+  overflow-x: hidden;
   margin: 1.75em 0;
   border-radius: 12px;
   border: 1px solid var(--prose-divider, rgba(128, 128, 128, 0.2));
   -webkit-overflow-scrolling: touch;
+  max-width: 100%;
 }
 
 .markdown-prose table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
   font-size: 0.95em;
 }
 
@@ -250,12 +258,16 @@
   padding: 0.85em 1em;
   border-bottom: 2px solid var(--prose-divider, rgba(128, 128, 128, 0.25));
   background: var(--prose-table-header-bg, rgba(103, 80, 164, 0.06));
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .markdown-prose tbody td {
   padding: 0.75em 1em;
   border-bottom: 1px solid var(--prose-divider, rgba(128, 128, 128, 0.12));
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .markdown-prose tbody tr:last-child td {
@@ -310,6 +322,17 @@
   margin: 1.5em 0;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+  max-width: 100%;
+}
+
+@media (max-width: 600px) {
+  .markdown-prose blockquote {
+    padding: 0.9em 1.1em;
+  }
+
+  .markdown-prose pre code {
+    padding: 1em;
+  }
 }
 
 /* ---- Night sky CSS variable overrides ---- */


### PR DESCRIPTION
Address horizontal overflow and wrapping issues across the note page and markdown prose, and simplify canvas positioning. NightSkyBackground: replace explicit top/left/vw/vh with inset: 0 and percent dimensions for more robust fixed positioning. NotePage: make container full-width with overflowX: 'clip', add minWidth: 0 to flex containers, and update Chips to allow long tags to break/wrap. markdown-prose.css: enforce width constraints (width/max-width/min-width), add overflow-wrap/word-break rules, set table-layout: fixed and hide horizontal overflow, tighten wrappers, and add small-screen padding tweaks for blockquotes and code blocks to improve responsiveness and prevent layout breaks.